### PR TITLE
Update hostname in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ services:
     ports:
       - 8754:8754
     environment:
-      - BEASTHOST=dockerhost
+      - BEASTHOST=piaware
       - FR24KEY=xxxxxxxxxxx
 ```
 


### PR DESCRIPTION
The hostname of the `piaware` container will be automatically
set & resolvable in the `fr24feed` container as `piaware`.