### PR TITLE
update signup.sh with better email regex

### DIFF
--- a/rootfs/scripts/signup.sh
+++ b/rootfs/scripts/signup.sh
@@ -3,7 +3,7 @@
 
 
 # Regular Expressions
-REGEX_PATTERN_VALID_EMAIL_ADDRESS='^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$'
+REGEX_PATTERN_VALID_EMAIL_ADDRESS='^[a-z0-9!#$%&*+=?^_‘{|}~-]+(?:\.[a-z0-9!$%&*+=?^_{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$'
 REGEX_PATTERN_FR24_SHARING_KEY='^\+ Your sharing key \((\w+)\) has been configured and emailed to you for backup purposes\.'
 REGEX_PATTERN_FR24_RADAR_ID='^\+ Your radar id is ([A-Za-z0-9\-]+), please include it in all email communication with us\.'
 


### PR DESCRIPTION
The previous email regex did not accept my valid custom email domain. This new regex is better suited for matching valid email addresses. 